### PR TITLE
Set the correct vscode engine compatibiltiy

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "version": "1.0.0",
     "publisher": "blairleduc",
     "engines": {
-        "vscode": "^1.18.0"
+        "vscode": "^1.26.0"
     },
     "categories": [
         "Extension Packs"


### PR DESCRIPTION
vscode engine should be set to `^1.26` because older VS Code versions does not support `extensionPack` property

@BlairLeduc  Please have this change before publishing the extension